### PR TITLE
Spaces index design

### DIFF
--- a/app/assets/stylesheets/components/_card.scss
+++ b/app/assets/stylesheets/components/_card.scss
@@ -1,0 +1,32 @@
+.card-product {
+  overflow: hidden;
+  height: 120px;
+  background: white;
+  box-shadow: 0 0 15px rgba(0,0,0,0.2);
+  display: flex;
+  align-items: center;
+}
+
+.card-product img {
+  height: 100%;
+  width: 120px;
+  object-fit: cover;
+}
+
+.card-product h2 {
+  font-size: 16px;
+  font-weight: bold;
+  margin: 0;
+}
+
+.card-product p {
+  font-size: 12px;
+  line-height: 1.4;
+  opacity: .7;
+  margin-bottom: 0;
+  margin-top: 8px;
+}
+
+.card-product .card-product-infos {
+  padding: 16px;
+}

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -8,10 +8,13 @@
 }
 
 #map {
-  top: 0;
+  position: fixed;
+  //top: 0;
   margin-top: 30px;
   border-radius: 1px;
   box-shadow: 0 0 10px rgba(0,0,0,0.2);
+  width: 50%;
+  height: 75%;
 }
 
 .card {

--- a/app/assets/stylesheets/components/_map.scss
+++ b/app/assets/stylesheets/components/_map.scss
@@ -9,7 +9,6 @@
 
 #map {
   position: fixed;
-  //top: 0;
   margin-top: 30px;
   border-radius: 1px;
   box-shadow: 0 0 10px rgba(0,0,0,0.2);

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -1,2 +1,3 @@
 // Import page-specific CSS files here.
 @import "home";
+@import "spaces";

--- a/app/assets/stylesheets/pages/_spaces.scss
+++ b/app/assets/stylesheets/pages/_spaces.scss
@@ -1,0 +1,5 @@
+#space-index {
+  min-height: 600px;
+  margin-bottom: 100px;
+  clear: both;
+}

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -24,6 +24,9 @@ class SpacesController < ApplicationController
 
   # added by Bruno
   def show
+    if params[:query].present?
+      params.delete :query
+    end
   end
 
   def create

--- a/app/controllers/spaces_controller.rb
+++ b/app/controllers/spaces_controller.rb
@@ -24,9 +24,7 @@ class SpacesController < ApplicationController
 
   # added by Bruno
   def show
-    if params[:query].present?
-      params.delete :query
-    end
+    params.delete :query if params[:query].present?
   end
 
   def create

--- a/app/javascript/init/mapbox.js
+++ b/app/javascript/init/mapbox.js
@@ -34,5 +34,5 @@ const addMarkersToMap = (map, markers) => {
 const fitMapToMarkers = (map, markers) => {
   const bounds = new mapboxgl.LngLatBounds();
   markers.forEach(marker => bounds.extend([ marker.longitude, marker.latitude ]));
-  map.fitBounds(bounds, { padding: 50, maxZoom: 15, duration: 1000 });
+  map.fitBounds(bounds, { padding: 70, maxZoom: 15, duration: 1000 });
 };

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -10,8 +10,9 @@
         <h1 class="display-4">Welcome to Desk Dash</h1>
         <p class="lead">Find your the workspace that's right for you</p>
         <hr class="my-4">
+
         <%= link_to spaces_path do %>
-          <button class="btn btn-secondary">Find a space now</button>
+          <button class="btn btn-secondary" data-turbolinks="false">Find a space now</button>
         <% end %>
 
       </div>

--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -1,28 +1,33 @@
-<div class="container pt-4">
+<div class="container pt-2">
   <div class="row">
 
   <div class="container my-3 col-12 col-lg-4">
     <% if @spaces.any? %>
       <div class="row">
         <% @spaces.each do |space| %>
-          <div class="card mx-3 my-3 card" style="width: 18rem;">
-            <img class="card-img-top" src="<%= space.photo %>" alt="<%= space.name %>"/>
-            <div class="card-body">
-              <h5 class="card-title"><%= space.name %></h5>
-              <%= link_to "Check it out", space_path(space), class: "btn btn-primary" %>
+
+          <div class="card-product mx-3 my-3">
+            <img src="<%= space.photo %>" alt="">
+            <div class="card-product-infos">
+              <h2><%= space.name %></h2>
+              <p><%= space.price %></p>
+              <%= link_to "Check it out", space_path(space), class: "btn btn-primary btn-sm" %>
             </div>
           </div>
+
         <% end %>
+
       </div>
     <% else %>
       <p>There are no spaces available!</p>
     <% end %>
   </div>
 
-    <div id="map" class="col-12 col-lg-8 position-sticky"
-         style="width: 100%; height: 600px"
-         data-markers="<%= @markers.to_json %>"
-         data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"
-    ></div>
+    <div class="col-12 col-lg-8 ">
+      <div id="map"
+           data-markers="<%= @markers.to_json %>"
+           data-mapbox-api-key="<%= ENV['MAPBOX_API_KEY'] %>"
+      ></div>
+    </div>
  </div>
 </div>

--- a/app/views/spaces/index.html.erb
+++ b/app/views/spaces/index.html.erb
@@ -1,4 +1,4 @@
-<div class="container pt-2">
+<div id="space-index" class="container pt-2">
   <div class="row">
 
   <div class="container my-3 col-12 col-lg-4">


### PR DESCRIPTION
The following were fixed/added:

- Map stays fixed as the user scrolls
- Map does not clip through footer when less than a certain number of resutls get displayed from a search
- Search queries now get properly deleted when the user returns to the home page in the same sessions and looks at all available spaces.
- disabled turbolinks when looking at the spaces index page to stop the map not loading in
- Changed the design of the cards on the spaces index page to make them easier to read
- increased the market paddign to force the map to load a bit more data nd stop it from randomly not displaying sections